### PR TITLE
RTSPClient.java fixes

### DIFF
--- a/sensorhub-driver-rtpcam/src/main/java/org/sensorhub/impl/sensor/rtpcam/RTSPClient.java
+++ b/sensorhub-driver-rtpcam/src/main/java/org/sensorhub/impl/sensor/rtpcam/RTSPClient.java
@@ -206,9 +206,11 @@ public class RTSPClient
         else if (requestType == REQ_DESCRIBE) {
             rtspRequestWriter.write("Accept: application/sdp" + CRLF);
         }
-        else {
-            // otherwise, write the Session ID
-            rtspRequestWriter.write("Session: " + rtspSessionID + CRLF);
+        else { 
+            if (rtspSessionID != "0") {
+                rtspRequestWriter.write("Session: " + rtspSessionID + CRLF);
+                log.trace("rtpsSessionId " + rtspSessionID);
+            }
         }
         
         // end header and flush
@@ -438,7 +440,7 @@ public class RTSPClient
                     }
                     else if (line.startsWith("a=fmtp:96"))
                     {
-                        for (String token: line.split("; "))
+                        for (String token: line.split(";"))
                         {
                             if (token.startsWith("sprop-parameter-sets"))
                             {


### PR DESCRIPTION
Modified RTSPClient to not send a SessionID to the RTSP Server when it is invalid/not known.
Modified RTSPClient to extract sprop-parameter-sets from a=fmtp:96 descriptor.